### PR TITLE
Fix/cursor lookup

### DIFF
--- a/src/modules/core/controller/event.v
+++ b/src/modules/core/controller/event.v
@@ -8,7 +8,14 @@ pub fn event_loop(input UserInput, x voidptr) {
 			handle_normal_mode_event(x, input.e, input.code)
 		}
 		.insert {
-			handle_insert_mode_event(x, input.e, input.code)
+			match input.code {
+				.up, .down, .left, .right {
+					handle_normal_mode_event(x, input.e, input.code)
+				}
+				else {
+					handle_insert_mode_event(x, input.e, input.code)
+				}
+			}
 		}
 		.command {
 			handle_command_mode_event(x, input.e, input.code)

--- a/src/modules/core/controller/events_normal.v
+++ b/src/modules/core/controller/events_normal.v
@@ -28,7 +28,7 @@ pub fn handle_normal_mode_event(x voidptr, event EventType, key KeyCode) {
 
 				wrap_points := app.viewport.build_wrap_points(line)
 				if wrap_points.len > 1 && buf.logical_cursor.x < wrap_points[wrap_points.len - 1] {
-					new_width := buf.logical_cursor.x + app.viewport.width - 1
+					new_width := buf.logical_cursor.x + app.viewport.width
 					if buf.logical_cursor.desired_col > new_width {
 						buf.logical_cursor.x = buf.logical_cursor.desired_col
 					} else {

--- a/src/modules/core/controller/events_normal.v
+++ b/src/modules/core/controller/events_normal.v
@@ -77,6 +77,8 @@ pub fn handle_normal_mode_event(x voidptr, event EventType, key KeyCode) {
 
 						buf.logical_cursor.x = 0
 						buf.logical_cursor.y = 0
+						buf.update_all_line_cache()
+
 						buf.update_visual_cursor(app.viewport.width)
 						buf.logical_cursor.update_desired_col(buf.visual_cursor.x, app.viewport.width)
 					}
@@ -87,6 +89,7 @@ pub fn handle_normal_mode_event(x voidptr, event EventType, key KeyCode) {
 					parent_dir, paths := fs.get_paths_from_parent_dir(buf.path)
 					buf.path = parent_dir
 					buf.lines = paths
+					buf.update_all_line_cache()
 
 					buf.logical_cursor.x = 0
 					buf.logical_cursor.y = 0

--- a/src/modules/core/init.v
+++ b/src/modules/core/init.v
@@ -34,7 +34,7 @@ pub fn App.new(file_path string, width int, height int) &App {
 	}
 
 	// viewport variables
-	col_offset := 3 // start of all text
+	col_offset := 4 // start of all text
 	view_height := height - 2 // subtract the command area
 	line_num_to_text_gap := 3 // space between line number and code
 	// total width available for code

--- a/src/modules/core/init.v
+++ b/src/modules/core/init.v
@@ -8,6 +8,7 @@ import os
 
 pub struct App {
 pub mut:
+	working_dir   string
 	buffers       []Buffer
 	active_buffer int
 	mode          Mode
@@ -19,6 +20,8 @@ pub mut:
 
 pub fn App.new(file_path string, width int, height int) &App {
 	mut app := &App{}
+
+	app.working_dir = os.abs_path('.')
 
 	app.theme = ColorScheme{
 		normal_text_color:          '#ffffff'
@@ -35,7 +38,7 @@ pub fn App.new(file_path string, width int, height int) &App {
 	view_height := height - 2 // subtract the command area
 	line_num_to_text_gap := 3 // space between line number and code
 	// total width available for code
-	view_width := width - (col_offset + line_num_to_text_gap) * 2
+	view_width := width - col_offset - line_num_to_text_gap
 	margin := 5 // lines to edge visible (for scrolling)
 	app.viewport = Viewport{
 		col_offset:           col_offset
@@ -58,7 +61,7 @@ pub fn App.new(file_path string, width int, height int) &App {
 
 	// app.viewport.update_width()
 
-	// go app.get_doctor_info()
+	go app.get_doctor_info()
 	return app
 }
 

--- a/src/modules/core/init.v
+++ b/src/modules/core/init.v
@@ -58,7 +58,7 @@ pub fn App.new(file_path string, width int, height int) &App {
 
 	// app.viewport.update_width()
 
-	go app.get_doctor_info()
+	// go app.get_doctor_info()
 	return app
 }
 

--- a/src/modules/ui/tui/ui_loop.v
+++ b/src/modules/ui/tui/ui_loop.v
@@ -5,6 +5,7 @@ import util
 import util.colors
 import term
 import math
+import fs
 
 fn ui_loop(x voidptr) {
 	mut tui_app := get_tui(x)
@@ -93,6 +94,12 @@ fn ui_loop(x voidptr) {
 			ctx.reset_color()
 		}
 
+		mut text_color := colors.white
+
+		if buf.is_directory_buffer && fs.is_dir(buf.path + line) {
+			text_color = colors.royal_blue
+		}
+
 		mut char_width := 1
 		for x_index, ch in runes {
 			visual_x_index := line_indices[x_index]
@@ -115,11 +122,13 @@ fn ui_loop(x voidptr) {
 				ctx.draw_text(x_pos + 1, y_pos + 1, printed.str().repeat(char_width))
 				ctx.reset_colors()
 			} else if y_index == buf.logical_cursor.y {
-				ctx.set_bg_color(theme.active_line_bg_color)
+				ctx.set_colors(theme.active_line_bg_color, text_color)
 				ctx.draw_text(x_pos + 1, y_pos + 1, printed.str().repeat(char_width))
-				ctx.reset_bg_color()
+				ctx.reset_colors()
 			} else {
+				ctx.set_color(text_color)
 				ctx.draw_text(x_pos + 1, y_pos + 1, printed.str().repeat(char_width))
+				ctx.reset_color()
 			}
 			char_width = 1
 		}
@@ -176,8 +185,7 @@ fn ui_loop(x voidptr) {
 	// ctx.draw_text(width - 30, height - 5, 'x: ' + buf.visual_cursor.y.str())
 	// ctx.draw_text(width - 30, height - 4, 'row_wrap: ' + num_wraps.str())
 	// ctx.draw_text(width - 30, height - 3, 'viewport end: ' + .str())
-	ctx.draw_text(width - 60, height - 2, 'desired col: ' + buf.path +
-		buf.lines[buf.logical_cursor.y].str())
+	// ctx.draw_text(width - 60, height - 2, os.join_path_single(buf.path, buf.lines[buf.logical_cursor.y]))
 
 	if app.mode == util.Mode.command {
 		buf.logical_cursor.x = app.cmd_buffer.command.len + 2

--- a/src/modules/ui/tui/ui_loop.v
+++ b/src/modules/ui/tui/ui_loop.v
@@ -80,7 +80,7 @@ fn ui_loop(x voidptr) {
 					break render_lines
 				}
 				// not sure why +3 on end x
-				ctx.draw_line(0, active_line_index, view.width + 5, active_line_index)
+				ctx.draw_line(0, active_line_index, width - 1, active_line_index)
 				ctx.draw_text(view.col_offset, i + wrap_offset + buffer_gap + 1, term.bold(line_num_label.str()))
 			}
 			ctx.reset_colors()

--- a/src/modules/ui/tui/util.v
+++ b/src/modules/ui/tui/util.v
@@ -31,21 +31,29 @@ fn (mut ctx TuiContext) draw_text_with_colors(bg_color ui.Color, fg_color ui.Col
 }
 
 fn (mut ctx TuiContext) get_cursor_colors(mode Mode, theme TuiTheme) (ui.Color, ui.Color) {
-	mut bg_color := theme.active_line_bg_color
-	if mode == .normal || mode == .command {
-		bg_color = theme.normal_cursor_color
-	} else if (ctx.frame_count / 15) % 2 == 0 {
-		// use frame_count to similute blinking cursor
-		// every 0.5 seconds (30 * 0.5)
-		bg_color = theme.insert_cursor_color
-	}
+	mut bg_color := theme.normal_cursor_color
+	mut fg_color := theme.cursor_text_color
+	if false {
+		// rough blinking cursor implementation
+		if mode != .normal && mode != .command {
+			bg_color = theme.active_line_bg_color
+			fg_color = theme.normal_text_color
+			if (ctx.frame_count / 10) % 2 == 0 {
+				// use frame_count to similute blinking cursor
+				// every 0.5 seconds (30 * 0.5)
+				bg_color = theme.insert_cursor_color
+				fg_color = theme.cursor_text_color
+			}
+		}
 
-	mut fg_color := theme.normal_text_color
-	if mode == .normal || mode == .command {
-		fg_color = theme.cursor_text_color
-	} else if (ctx.frame_count / 15) % 2 == 0 {
-		fg_color = theme.cursor_text_color
-	}
+		return bg_color, fg_color
+	} else {
+		// default
 
-	return bg_color, fg_color
+		if mode != .normal && mode != .command {
+			bg_color = theme.insert_cursor_color
+			fg_color = theme.cursor_text_color
+		}
+		return bg_color, fg_color
+	}
 }

--- a/src/modules/util/colors/tui-colors.v
+++ b/src/modules/util/colors/tui-colors.v
@@ -95,6 +95,11 @@ pub const dark_blue = Color{
 	g: 0
 	b: 139
 }
+pub const dark_grey_blue = Color{
+	r: 40
+	g: 44
+	b: 52
+}
 
 pub const muted_dark_blue = Color{
 	r: 25


### PR DESCRIPTION
Rewrote ui_loop to ensure cursor movement recognizes multi-line lines. Also added some touches to ui coloring and normalized arrow key functionality. 

This branch's main focus was aligning the cursor to the expected position as well as making the ui_loop more efficient. However, there are still a few issues with the logic of the cursor movement:

- moving up the buffer doesn't move to the last wrapped line of the previous line. Rather it moves to the first line of the previous line.

- inserting into a tab doesn't remove the tab character (unsure what the expected behavior of this should be)